### PR TITLE
'Print Manifest' fix

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/hibernate/HibernateKenyaemrOrdersDAO.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/hibernate/HibernateKenyaemrOrdersDAO.java
@@ -120,7 +120,8 @@ public class HibernateKenyaemrOrdersDAO implements KenyaemrOrdersDAO {
         Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(LabManifestOrder.class);
         criteria.add(Restrictions.eq("labManifest", labManifest));
         criteria.add(Restrictions.eq("voided", false));
-        criteria.addOrder(org.hibernate.criterion.Order.asc("id"));
+        //criteria.addOrder(org.hibernate.criterion.Order.asc("id"));
+        criteria.addOrder(org.hibernate.criterion.Order.asc("dateSent"));
         return criteria.list();
     }
 

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabwareSystemWebRequest.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabwareSystemWebRequest.java
@@ -157,6 +157,7 @@ public class LabwareSystemWebRequest extends LabWebRequest {
                 return(false);
             } else if (statusCode == 201 || statusCode == 200) {
                 manifestOrder.setStatus("Sent");
+                manifestOrder.setDateSent(new Date());
                 System.out.println("Labware Lab Results POST: Successfully pushed a VL lab test id " + manifestOrder.getId());
                 log.info("Labware Lab Results POST: Successfully pushed a VL lab test id " + manifestOrder.getId());
                 kenyaemrOrdersService.saveLabManifestOrder(manifestOrder);

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -293,4 +293,11 @@
         </addColumn>
     </changeSet>
 
+    <changeSet author="pwaweru" id="kenyaemr_order_entry_unique_order_per_manifest_20221118_183100">
+        <createIndex indexName="index_manifest_order_unique_order_per_manifest" tableName="kenyaemr_order_entry_lab_manifest_order" unique="true">
+            <column name="manifest_id"/>
+            <column name="order_id"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/omod/src/main/webapp/pages/orders/manifestOrdersHome.gsp
+++ b/omod/src/main/webapp/pages/orders/manifestOrdersHome.gsp
@@ -98,7 +98,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
             </button>
                     </td>
             <% } %>
-            <% if (manifestOrders.size() > 0 && manifest.status.trim().toLowerCase() == 'submitted') { %>
+            <% if (manifestOrders.size() > 0 && (manifest.status != null && manifest.status.trim().toLowerCase() == 'submitted')) { %>
                     <td>
                         <a href="${ ui.pageLink("kenyaemrorderentry","manifest/downloadManifest",[manifest : manifest.id]) }"   target="_blank">
                             <button style="background-color: cadetblue; color: white">

--- a/omod/src/main/webapp/pages/orders/manifestOrdersHome.gsp
+++ b/omod/src/main/webapp/pages/orders/manifestOrdersHome.gsp
@@ -98,7 +98,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
             </button>
                     </td>
             <% } %>
-            <% if (manifestOrders.size() > 0) { %>
+            <% if (manifestOrders.size() > 0 && manifest.status.trim().toLowerCase() == 'submitted') { %>
                     <td>
                         <a href="${ ui.pageLink("kenyaemrorderentry","manifest/downloadManifest",[manifest : manifest.id]) }"   target="_blank">
                             <button style="background-color: cadetblue; color: white">
@@ -223,24 +223,24 @@ tr:nth-child(even) {background-color: #f2f2f2;}
                     <span style="color: firebrick" id="msgBox"></span>
                     <table>
                         <tr>
-                            <td>Sample type</td>
+                            <td>Sample type *</td>
                             <td>
                                 <select id="sampleType">
-                                    <option>select ...</option>
                                     <% if(manifest.manifestType == 2) { %>
                                         <option value="Frozen plasma">Frozen plasma</option>
                                         <option value="Whole Blood">Whole Blood</option>
+                                    <% } else if(manifest.manifestType == 1) {%>
+                                        <option value="DBS">DBS</option>
                                     <% } %>
-                                    <option value="DBS">DBS</option>
                                 </select>
                             </td>
                         </tr>
                         <tr>
-                            <td>Sample collection date</td>
+                            <td>Sample collection date *</td>
                             <td>${ ui.includeFragment("kenyaui", "field/java.util.Date", [ id: "dateSampleCollected", formFieldName: "dateSampleCollected"]) }</td>
                         </tr>
                         <tr>
-                            <td>Sample separation/centrifugation date</td>
+                            <td>Sample separation/centrifugation date *</td>
                             <td>${ ui.includeFragment("kenyaui", "field/java.util.Date", [ id: "dateSampleSeparated", formFieldName: "dateSampleSeparated"]) }</td>
                         </tr>
                     </table>
@@ -362,7 +362,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
             var dSeparated = new Date(dateSampleSeparated);
             var dToday = new Date();
 
-            if (dateSampleCollected == "" || dateSampleSeparated == "" || sampleType == "") {
+            if ( dateSampleCollected == "" || dateSampleSeparated == "" || sampleType == "" || sampleType == null || !sampleType ) {
                 jq('.modal-body #msgBox').text('Please fill all fields');
             }else if (dateSampleCollected > dToday){
                 jq('.modal-body #msgBox').text('Sample collection date cannot be in future');


### PR DESCRIPTION
1. Enable 'Print Manifest' button only after the full manifest is submitted
2. Print manifest order ordered by date and time sent ascending
3. fix sample type bug - select field should only have valid values 
4. make sure an order can only be added once per manifest using a DB unique index