### PR TITLE
KHP3-3443 lab manifest add new categories for manifests in error and in sending status

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/KenyaemrOrdersDAO.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/KenyaemrOrdersDAO.java
@@ -78,5 +78,6 @@ public interface KenyaemrOrdersDAO {
 
     LabManifest getFirstLabManifestByOrderStatusCheckedBeforeDate(String status, Date lastStatusCheckDate);
 
+    void requeueLabManifest(Integer manifestId);
     //End of Patient Contact dimensions methods
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/KenyaemrOrdersDAO.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/KenyaemrOrdersDAO.java
@@ -78,6 +78,6 @@ public interface KenyaemrOrdersDAO {
 
     LabManifest getFirstLabManifestByOrderStatusCheckedBeforeDate(String status, Date lastStatusCheckDate);
 
-    void requeueLabManifest(Integer manifestId);
+    void reprocessLabManifest(Integer manifestId);
     //End of Patient Contact dimensions methods
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/hibernate/HibernateKenyaemrOrdersDAO.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/hibernate/HibernateKenyaemrOrdersDAO.java
@@ -430,8 +430,14 @@ public class HibernateKenyaemrOrdersDAO implements KenyaemrOrdersDAO {
         return null;
     }
 
+    /**
+     * This puts the manifest in the submitted state allowing the system to check for results from remote again
+     * It also changes the status of the manifest samples in error to "Sent"
+     * 
+     * @param manifestId - The manifest id
+     */
     @Override
-    public void requeueLabManifest(Integer manifestId) {
+    public void reprocessLabManifest(Integer manifestId) {
         LabManifest labManifest = getLabOrderManifestById(manifestId);
         labManifest.setStatus("Submitted");
         saveLabOrderManifest(labManifest);

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/hibernate/HibernateKenyaemrOrdersDAO.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/db/hibernate/HibernateKenyaemrOrdersDAO.java
@@ -430,4 +430,21 @@ public class HibernateKenyaemrOrdersDAO implements KenyaemrOrdersDAO {
         return null;
     }
 
+    @Override
+    public void requeueLabManifest(Integer manifestId) {
+        LabManifest labManifest = getLabOrderManifestById(manifestId);
+        labManifest.setStatus("Submitted");
+        saveLabOrderManifest(labManifest);
+        //get all orders in manifest
+        List<LabManifestOrder> ordersList = getLabManifestOrderByManifest(labManifest);
+        for (LabManifestOrder labManifestOrder : ordersList) {
+            // Modify the order in case the status is in error
+            String status = labManifestOrder.getStatus();
+            if(!status.trim().equalsIgnoreCase("Complete")) {
+                labManifestOrder.setStatus("Sent");
+                saveLabManifestOrder(labManifestOrder);
+            }
+        }
+    }
+
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/KenyaemrOrdersService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/KenyaemrOrdersService.java
@@ -12,7 +12,7 @@ import java.util.Date;
 import java.util.List;
 
 public interface KenyaemrOrdersService extends OpenmrsService {
-    void requeueLabManifest(Integer manifestId);
+    void reprocessLabManifest(Integer manifestId);
     LabManifest saveLabOrderManifest(LabManifest labManifest);
     Long getLastManifestID();
     List<LabManifest> getLabOrderManifest();

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/KenyaemrOrdersService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/KenyaemrOrdersService.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.List;
 
 public interface KenyaemrOrdersService extends OpenmrsService {
+    void requeueLabManifest(Integer manifestId);
     LabManifest saveLabOrderManifest(LabManifest labManifest);
     Long getLastManifestID();
     List<LabManifest> getLabOrderManifest();
@@ -52,5 +53,4 @@ public interface KenyaemrOrdersService extends OpenmrsService {
     public Cohort getPatientContactWithAgeRange(Integer minAge, DurationUnit minAgeUnit, Integer maxAge, DurationUnit maxAgeUnit, boolean unknownAgeIncluded, Date effectiveDate);
 
     //End of Patient contact dimensions service methods
-
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/impl/KenyaemrOrdersServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/impl/KenyaemrOrdersServiceImpl.java
@@ -218,4 +218,10 @@ public class KenyaemrOrdersServiceImpl extends BaseOpenmrsService implements Ken
     public void onShutdown() {
 
     }
+
+    @Override
+    @Transactional(readOnly = false)
+    public void requeueLabManifest(Integer manifestId) {
+        dao.requeueLabManifest(manifestId);
+    }
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/impl/KenyaemrOrdersServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/impl/KenyaemrOrdersServiceImpl.java
@@ -221,7 +221,7 @@ public class KenyaemrOrdersServiceImpl extends BaseOpenmrsService implements Ken
 
     @Override
     @Transactional(readOnly = false)
-    public void requeueLabManifest(Integer manifestId) {
-        dao.requeueLabManifest(manifestId);
+    public void reprocessLabManifest(Integer manifestId) {
+        dao.reprocessLabManifest(manifestId);
     }
 }

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/fragment/controller/manifest/ManifestFormFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/fragment/controller/manifest/ManifestFormFragmentController.java
@@ -86,7 +86,7 @@ public class ManifestFormFragmentController {
     public void requeueManifest(@RequestParam("manifestId") Integer manifestId, @SpringBean KenyaUiUtils kenyaUi, UiUtils ui) {
         // We requeue the manifest by changing its status to 'Submitted' and all order items to 'Sent'
         KenyaemrOrdersService kenyaemrOrdersService = Context.getService(KenyaemrOrdersService.class);
-        kenyaemrOrdersService.requeueLabManifest(manifestId);
+        kenyaemrOrdersService.reprocessLabManifest(manifestId);
     }
 
     private List<String> manifestStatus() {

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/fragment/controller/manifest/ManifestFormFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/fragment/controller/manifest/ManifestFormFragmentController.java
@@ -26,6 +26,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyaemrorderentry.api.service.KenyaemrOrdersService;
+import org.openmrs.module.kenyaemrorderentry.manifest.LabManifest;
+import org.openmrs.module.kenyaemrorderentry.manifest.LabManifestOrder;
+import org.openmrs.module.kenyaui.KenyaUiUtils;
+import org.openmrs.module.kenyaui.annotation.AppPage;
+import org.openmrs.ui.framework.SimpleObject;
+import org.openmrs.ui.framework.UiUtils;
+import org.openmrs.ui.framework.annotation.SpringBean;
+import org.openmrs.ui.framework.page.PageModel;
+import org.springframework.web.bind.annotation.RequestParam;
+
 public class ManifestFormFragmentController {
     public void controller(@FragmentParam(value = "manifestId", required = false) LabManifest labManifest,
                            @RequestParam(value = "returnUrl") String returnUrl,
@@ -60,6 +75,18 @@ public class ManifestFormFragmentController {
         model.addAttribute("countyList", uniqueCountyList);
         model.addAttribute("isAnEdit", exists == null ? false : true);
         model.addAttribute("returnUrl", returnUrl);
+    }
+
+    /**
+     * Requeue a manifest that has errors
+     * @param manifestId
+     * @param kenyaUi
+     * @param ui
+     */
+    public void requeueManifest(@RequestParam("manifestId") Integer manifestId, @SpringBean KenyaUiUtils kenyaUi, UiUtils ui) {
+        // We requeue the manifest by changing its status to 'Submitted' and all order items to 'Sent'
+        KenyaemrOrdersService kenyaemrOrdersService = Context.getService(KenyaemrOrdersService.class);
+        kenyaemrOrdersService.requeueLabManifest(manifestId);
     }
 
     private List<String> manifestStatus() {

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersCompleteResultManifestHomePageController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersCompleteResultManifestHomePageController.java
@@ -33,39 +33,42 @@ public class LabOrdersCompleteResultManifestHomePageController {
             List<LabManifestOrder> missingInLab = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Record not found");
             List<LabManifestOrder> allSamples = kenyaemrOrdersService.getLabManifestOrderByManifest(manifest);
 
-            String manifestType = "";
-            if (manifest.getManifestType() != null && manifest.getManifestType().intValue() == 1) {
-                manifestType = "EID";
-            } else if (manifest.getManifestType() != null && manifest.getManifestType().intValue() == 2) {
-                manifestType = "VL";
+            if(ordersWithIncompleteResult.size() == 0 &&
+                    missingInLab.size() == 0) {
+                String manifestType = "";
+                if (manifest.getManifestType() != null && manifest.getManifestType().intValue() == LabManifest.EID_TYPE) {
+                    manifestType = "EID";
+                } else if (manifest.getManifestType() != null && manifest.getManifestType().intValue() == LabManifest.VL_TYPE) {
+                    manifestType = "VL";
+                }
+                SimpleObject m = SimpleObject.create(
+                        "id", manifest.getId(),
+                        "startDate", manifest.getStartDate() != null ? ui.formatDatePretty(manifest.getStartDate()) : "",
+                        "endDate", manifest.getEndDate() != null ? ui.formatDatePretty(manifest.getEndDate()) : "",
+                        "manifestType", manifestType,
+                        "dispatchDate", manifest.getDispatchDate() != null ? ui.formatDatePretty(manifest.getDispatchDate()) : "",
+                        "courier", StringUtils.capitalize(manifest.getCourier() != null ? manifest.getCourier().toLowerCase() : ""),
+                        "courierOfficer", StringUtils.capitalize(manifest.getCourierOfficer() != null ? manifest.getCourierOfficer().toLowerCase() : ""),
+                        "status", manifest.getStatus(),
+                        "facilityEmail", manifest.getFacilityEmail(),
+                        "identifier", manifest.getIdentifier() != null ? manifest.getIdentifier() : "",
+                        "facilityPhoneContact", manifest.getFacilityPhoneContact(),
+                        "clinicianPhoneContact", manifest.getClinicianPhoneContact(),
+                        "clinicianName", StringUtils.capitalize(manifest.getClinicianName() != null ? manifest.getClinicianName().toLowerCase() : ""),
+                        "labPocPhoneNumber", manifest.getLabPocPhoneNumber()
+
+                );
+
+                SimpleObject o1 = SimpleObject.create(
+                        "manifest", m,
+                        "collectNewSample", collectNewSampleOrders.size(),
+                        "incompleteSample", ordersWithIncompleteResult.size(),
+                        "manualUpdates", manualDiscontinuationOrders.size(),
+                        "recordsNotFound", missingInLab.size(),
+                        "totalSamples", allSamples.size(),
+                        "missingPhysicalSample", ordersWithMissingPhysicalSamples.size());
+                manifestList1.add(o1);
             }
-            SimpleObject m = SimpleObject.create(
-                    "id", manifest.getId(),
-                    "startDate", manifest.getStartDate() != null ? ui.formatDatePretty(manifest.getStartDate()) : "",
-                    "endDate", manifest.getEndDate() != null ? ui.formatDatePretty(manifest.getEndDate()) : "",
-                    "manifestType", manifestType,
-                    "dispatchDate", manifest.getDispatchDate() != null ? ui.formatDatePretty(manifest.getDispatchDate()) : "",
-                    "courier", StringUtils.capitalize(manifest.getCourier() != null ? manifest.getCourier().toLowerCase() : ""),
-                    "courierOfficer", StringUtils.capitalize(manifest.getCourierOfficer() != null ? manifest.getCourierOfficer().toLowerCase() : ""),
-                    "status", manifest.getStatus(),
-                    "facilityEmail", manifest.getFacilityEmail(),
-                    "identifier", manifest.getIdentifier() != null ? manifest.getIdentifier() : "",
-                    "facilityPhoneContact", manifest.getFacilityPhoneContact(),
-                    "clinicianPhoneContact", manifest.getClinicianPhoneContact(),
-                    "clinicianName", StringUtils.capitalize(manifest.getClinicianName() != null ? manifest.getClinicianName().toLowerCase() : ""),
-                    "labPocPhoneNumber", manifest.getLabPocPhoneNumber()
-
-            );
-
-            SimpleObject o1 = SimpleObject.create(
-                    "manifest", m,
-                    "collectNewSample", collectNewSampleOrders.size(),
-                    "incompleteSample", ordersWithIncompleteResult.size(),
-                    "manualUpdates", manualDiscontinuationOrders.size(),
-                    "recordsNotFound", missingInLab.size(),
-                    "totalSamples", allSamples.size(),
-                    "missingPhysicalSample", ordersWithMissingPhysicalSamples.size());
-            manifestList1.add(o1);
         }
         model.put("manifestList", ui.toJson(manifestList1));
         model.put("manifestListSize", ui.toJson(manifestList1.size()));

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersCompleteWithErrorResultsManifestHomePageController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersCompleteWithErrorResultsManifestHomePageController.java
@@ -1,0 +1,76 @@
+package org.openmrs.module.kenyaemrorderentry.page.controller.orders;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyaemrorderentry.api.service.KenyaemrOrdersService;
+import org.openmrs.module.kenyaemrorderentry.manifest.LabManifest;
+import org.openmrs.module.kenyaemrorderentry.manifest.LabManifestOrder;
+import org.openmrs.module.kenyaui.KenyaUiUtils;
+import org.openmrs.module.kenyaui.annotation.AppPage;
+import org.openmrs.ui.framework.SimpleObject;
+import org.openmrs.ui.framework.UiUtils;
+import org.openmrs.ui.framework.annotation.SpringBean;
+import org.openmrs.ui.framework.page.PageModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AppPage("kenyaemr.labmanifest")
+public class LabOrdersCompleteWithErrorResultsManifestHomePageController {
+
+    KenyaemrOrdersService kenyaemrOrdersService = Context.getService(KenyaemrOrdersService.class);
+
+    public void get(@SpringBean KenyaUiUtils kenyaUi, UiUtils ui, PageModel model) {
+        List<LabManifest> allManifests = Context.getService(KenyaemrOrdersService.class).getLabOrderManifest("Complete With Error results");
+        List<SimpleObject> manifestList1 = new ArrayList<SimpleObject>();
+        for (LabManifest manifest : allManifests) {
+
+            List<LabManifestOrder> ordersWithIncompleteResult = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Incomplete");
+            List<LabManifestOrder> collectNewSampleOrders = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Collect New Sample");
+            List<LabManifestOrder> manualDiscontinuationOrders = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Requires manual update in the lab module");
+            List<LabManifestOrder> ordersWithMissingPhysicalSamples = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Missing Sample ( Physical Sample Missing)");
+            List<LabManifestOrder> missingInLab = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Record not found");
+            List<LabManifestOrder> allSamples = kenyaemrOrdersService.getLabManifestOrderByManifest(manifest);
+
+            if(ordersWithIncompleteResult.size() > 0 ||
+                    missingInLab.size() > 0) {
+                String manifestType = "";
+                if (manifest.getManifestType() != null && manifest.getManifestType().intValue() == LabManifest.EID_TYPE) {
+                    manifestType = "EID";
+                } else if (manifest.getManifestType() != null && manifest.getManifestType().intValue() == LabManifest.VL_TYPE) {
+                    manifestType = "VL";
+                }
+                SimpleObject m = SimpleObject.create(
+                        "id", manifest.getId(),
+                        "startDate", manifest.getStartDate() != null ? ui.formatDatePretty(manifest.getStartDate()) : "",
+                        "endDate", manifest.getEndDate() != null ? ui.formatDatePretty(manifest.getEndDate()) : "",
+                        "manifestType", manifestType,
+                        "dispatchDate", manifest.getDispatchDate() != null ? ui.formatDatePretty(manifest.getDispatchDate()) : "",
+                        "courier", StringUtils.capitalize(manifest.getCourier() != null ? manifest.getCourier().toLowerCase() : ""),
+                        "courierOfficer", StringUtils.capitalize(manifest.getCourierOfficer() != null ? manifest.getCourierOfficer().toLowerCase() : ""),
+                        "status", manifest.getStatus(),
+                        "facilityEmail", manifest.getFacilityEmail(),
+                        "identifier", manifest.getIdentifier() != null ? manifest.getIdentifier() : "",
+                        "facilityPhoneContact", manifest.getFacilityPhoneContact(),
+                        "clinicianPhoneContact", manifest.getClinicianPhoneContact(),
+                        "clinicianName", StringUtils.capitalize(manifest.getClinicianName() != null ? manifest.getClinicianName().toLowerCase() : ""),
+                        "labPocPhoneNumber", manifest.getLabPocPhoneNumber()
+
+                );
+
+                SimpleObject o1 = SimpleObject.create(
+                        "manifest", m,
+                        "collectNewSample", collectNewSampleOrders.size(),
+                        "incompleteSample", ordersWithIncompleteResult.size(),
+                        "manualUpdates", manualDiscontinuationOrders.size(),
+                        "recordsNotFound", missingInLab.size(),
+                        "totalSamples", allSamples.size(),
+                        "missingPhysicalSample", ordersWithMissingPhysicalSamples.size());
+                manifestList1.add(o1);
+            }
+        }
+        model.put("manifestList", ui.toJson(manifestList1));
+        model.put("manifestListSize", ui.toJson(manifestList1.size()));
+    }
+
+}

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersCompleteWithErrorResultsManifestHomePageController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersCompleteWithErrorResultsManifestHomePageController.java
@@ -1,5 +1,8 @@
 package org.openmrs.module.kenyaemrorderentry.page.controller.orders;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.kenyaemrorderentry.api.service.KenyaemrOrdersService;
@@ -11,9 +14,7 @@ import org.openmrs.ui.framework.SimpleObject;
 import org.openmrs.ui.framework.UiUtils;
 import org.openmrs.ui.framework.annotation.SpringBean;
 import org.openmrs.ui.framework.page.PageModel;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @AppPage("kenyaemr.labmanifest")
 public class LabOrdersCompleteWithErrorResultsManifestHomePageController {
@@ -21,7 +22,7 @@ public class LabOrdersCompleteWithErrorResultsManifestHomePageController {
     KenyaemrOrdersService kenyaemrOrdersService = Context.getService(KenyaemrOrdersService.class);
 
     public void get(@SpringBean KenyaUiUtils kenyaUi, UiUtils ui, PageModel model) {
-        List<LabManifest> allManifests = Context.getService(KenyaemrOrdersService.class).getLabOrderManifest("Complete With Error results");
+        List<LabManifest> allManifests = Context.getService(KenyaemrOrdersService.class).getLabOrderManifest("Complete results");
         List<SimpleObject> manifestList1 = new ArrayList<SimpleObject>();
         for (LabManifest manifest : allManifests) {
 
@@ -72,5 +73,17 @@ public class LabOrdersCompleteWithErrorResultsManifestHomePageController {
         model.put("manifestList", ui.toJson(manifestList1));
         model.put("manifestListSize", ui.toJson(manifestList1.size()));
     }
+
+    /**
+     * Requeue a manifest that has errors
+     * @param manifestId
+     * @param kenyaUi
+     * @param ui
+     */
+    // public void requeueManifest(@RequestParam("manifestId") Integer manifestId, @SpringBean KenyaUiUtils kenyaUi, UiUtils ui) {
+    //     // We requeue the manifest by changing its status to 'Submitted' and all order items to 'Sent'
+    //     KenyaemrOrdersService kenyaemrOrdersService = Context.getService(KenyaemrOrdersService.class);
+    //     kenyaemrOrdersService.requeueLabManifest(manifestId);
+    // }
 
 }

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersCompleteWithErrorResultsManifestHomePageController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersCompleteWithErrorResultsManifestHomePageController.java
@@ -14,7 +14,6 @@ import org.openmrs.ui.framework.SimpleObject;
 import org.openmrs.ui.framework.UiUtils;
 import org.openmrs.ui.framework.annotation.SpringBean;
 import org.openmrs.ui.framework.page.PageModel;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @AppPage("kenyaemr.labmanifest")
 public class LabOrdersCompleteWithErrorResultsManifestHomePageController {
@@ -73,17 +72,5 @@ public class LabOrdersCompleteWithErrorResultsManifestHomePageController {
         model.put("manifestList", ui.toJson(manifestList1));
         model.put("manifestListSize", ui.toJson(manifestList1.size()));
     }
-
-    /**
-     * Requeue a manifest that has errors
-     * @param manifestId
-     * @param kenyaUi
-     * @param ui
-     */
-    // public void requeueManifest(@RequestParam("manifestId") Integer manifestId, @SpringBean KenyaUiUtils kenyaUi, UiUtils ui) {
-    //     // We requeue the manifest by changing its status to 'Submitted' and all order items to 'Sent'
-    //     KenyaemrOrdersService kenyaemrOrdersService = Context.getService(KenyaemrOrdersService.class);
-    //     kenyaemrOrdersService.requeueLabManifest(manifestId);
-    // }
 
 }

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersSendingManifestHomePageController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/page/controller/orders/LabOrdersSendingManifestHomePageController.java
@@ -1,0 +1,73 @@
+package org.openmrs.module.kenyaemrorderentry.page.controller.orders;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyaemrorderentry.api.service.KenyaemrOrdersService;
+import org.openmrs.module.kenyaemrorderentry.manifest.LabManifest;
+import org.openmrs.module.kenyaemrorderentry.manifest.LabManifestOrder;
+import org.openmrs.module.kenyaui.KenyaUiUtils;
+import org.openmrs.module.kenyaui.annotation.AppPage;
+import org.openmrs.ui.framework.SimpleObject;
+import org.openmrs.ui.framework.UiUtils;
+import org.openmrs.ui.framework.annotation.SpringBean;
+import org.openmrs.ui.framework.page.PageModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AppPage("kenyaemr.labmanifest")
+public class LabOrdersSendingManifestHomePageController {
+
+    KenyaemrOrdersService kenyaemrOrdersService = Context.getService(KenyaemrOrdersService.class);
+
+    public void get(@SpringBean KenyaUiUtils kenyaUi, UiUtils ui, PageModel model) {
+        List<LabManifest> allManifests = Context.getService(KenyaemrOrdersService.class).getLabOrderManifest("Sending");
+        List<SimpleObject> manifestList1 = new ArrayList<SimpleObject>();
+        for (LabManifest manifest : allManifests) {
+
+            List<LabManifestOrder> ordersWithIncompleteResult = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Incomplete");
+            List<LabManifestOrder> collectNewSampleOrders = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Collect New Sample");
+            List<LabManifestOrder> manualDiscontinuationOrders = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Requires manual update in the lab module");
+            List<LabManifestOrder> ordersWithMissingPhysicalSamples = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Missing Sample ( Physical Sample Missing)");
+            List<LabManifestOrder> missingInLab = kenyaemrOrdersService.getLabManifestOrderByManifestAndStatus(manifest, "Record not found");
+            List<LabManifestOrder> allSamples = kenyaemrOrdersService.getLabManifestOrderByManifest(manifest);
+
+            String manifestType = "";
+            if (manifest.getManifestType() != null && manifest.getManifestType().intValue() == LabManifest.EID_TYPE) {
+                manifestType = "EID";
+            } else if (manifest.getManifestType() != null && manifest.getManifestType().intValue() == LabManifest.VL_TYPE) {
+                manifestType = "VL";
+            }
+            SimpleObject m = SimpleObject.create(
+                    "id", manifest.getId(),
+                    "startDate", manifest.getStartDate() != null ? ui.formatDatePretty(manifest.getStartDate()) : "",
+                    "endDate", manifest.getEndDate() != null ? ui.formatDatePretty(manifest.getEndDate()) : "",
+                    "manifestType", manifestType,
+                    "dispatchDate", manifest.getDispatchDate() != null ? ui.formatDatePretty(manifest.getDispatchDate()) : "",
+                    "courier", StringUtils.capitalize(manifest.getCourier() != null ? manifest.getCourier().toLowerCase() : ""),
+                    "courierOfficer", StringUtils.capitalize(manifest.getCourierOfficer() != null ? manifest.getCourierOfficer().toLowerCase() : ""),
+                    "status", manifest.getStatus(),
+                    "facilityEmail", manifest.getFacilityEmail(),
+                    "identifier", manifest.getIdentifier() != null ? manifest.getIdentifier() : "",
+                    "facilityPhoneContact", manifest.getFacilityPhoneContact(),
+                    "clinicianPhoneContact", manifest.getClinicianPhoneContact(),
+                    "clinicianName", StringUtils.capitalize(manifest.getClinicianName() != null ? manifest.getClinicianName().toLowerCase() : ""),
+                    "labPocPhoneNumber", manifest.getLabPocPhoneNumber()
+
+            );
+
+            SimpleObject o1 = SimpleObject.create(
+                    "manifest", m,
+                    "collectNewSample", collectNewSampleOrders.size(),
+                    "incompleteSample", ordersWithIncompleteResult.size(),
+                    "manualUpdates", manualDiscontinuationOrders.size(),
+                    "recordsNotFound", missingInLab.size(),
+                    "totalSamples", allSamples.size(),
+                    "missingPhysicalSample", ordersWithMissingPhysicalSamples.size());
+            manifestList1.add(o1);
+        }
+        model.put("manifestList", ui.toJson(manifestList1));
+        model.put("manifestListSize", ui.toJson(manifestList1.size()));
+    }
+
+}

--- a/omod/src/main/webapp/fragments/manifest/manifestForm.gsp
+++ b/omod/src/main/webapp/fragments/manifest/manifestForm.gsp
@@ -156,7 +156,7 @@
                         <select name="status" id="status">
                             <option></option>
                             <% manifestStatusOptions.each { %>
-                            <option ${(command.status == null)? "" : it == command.status ? "selected" : ""} value="${it}">${it}</option>
+                                <option ${(command.status == null)? "" : it == command.status ? "selected" : ""} value="${it}">${it}</option>
                             <% } %>
                         </select>
                     </td>

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteResultManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteResultManifestHome.gsp
@@ -94,10 +94,14 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 .viewButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .editButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .viewButton:hover {
     background-color: steelblue;

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteResultManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteResultManifestHome.gsp
@@ -12,6 +12,7 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteResultManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteResultManifestHome.gsp
@@ -14,6 +14,7 @@
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
+            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
             [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ""],
     ]
 

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
@@ -354,7 +354,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
             }
 
             var btnRequeue = jq('<button/>', {
-                text: 'Re-queue',
+                text: 'Re-process',
                 class: 'requeueButton',
                 value: displayRecords[i].manifest.id
             });

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
@@ -12,6 +12,7 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ""],

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
@@ -236,7 +236,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
             console.log('Manifest ID: ' + JSON.stringify(manifestId));
             ui.getFragmentActionAsJson('kenyaemrorderentry', 'manifest/manifestForm', 'requeueManifest', {manifestId : manifestId}, function (result) {
                 // Done Requeueing
-                alert("Success: Manifest Number: " + manifestId + " requeued");
+                console.log("Success: Manifest Number: " + manifestId + " requeued");
                 ui.reloadPage();
                 //ui.navigate('kenyaemrorderentry', 'orders/labOrdersSubmittedManifestHome', { manifestId: jq(this).val(),  returnUrl: location.href });
             }); 

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
@@ -94,14 +94,20 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 .viewButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .editButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .requeueButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .viewButton:hover {
     background-color: steelblue;
@@ -133,7 +139,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 <div class="ke-page-content">
     <div align="left">
 
-        <h2 style="color:steelblue">Manifest list [ Complete With Error Results ]</h2>
+        <h2 style="color:steelblue">Manifest list [ Complete With Errors ]</h2>
         <div>
 
         </div>
@@ -174,7 +180,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
     jq = jQuery;
     jq(function () {
         // mark the activePage
-        showActivePageOnManifestNavigation('Complete With Error results');
+        showActivePageOnManifestNavigation('Complete With Errors');
         jq('#generateManifest').click(function () {
             jq.getJSON('${ ui.actionLink("kenyaemrorderentry", "patientdashboard/generalLabOrders", "generateViralLoadPayload") }')
                 .success(function (data) {
@@ -222,6 +228,31 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 
         jq(document).on('click','.editButton',function(){
             ui.navigate('kenyaemrorderentry', 'manifest/createManifest', { manifestId: jq(this).val(),  returnUrl: location.href });
+        });
+
+        jq(document).on('click','.requeueButton',function(){
+            // We requeue the manifest by changing its status to 'Submitted' and all order items to 'Sent'
+            let manifestId = jq(this).val();
+            console.log('Manifest ID: ' + JSON.stringify(manifestId));
+            ui.getFragmentActionAsJson('kenyaemrorderentry', 'manifest/manifestForm', 'requeueManifest', {manifestId : manifestId}, function (result) {
+                // Done Requeueing
+                alert("Success: Manifest Number: " + manifestId + " requeued");
+                ui.reloadPage();
+                //ui.navigate('kenyaemrorderentry', 'orders/labOrdersSubmittedManifestHome', { manifestId: jq(this).val(),  returnUrl: location.href });
+            }); 
+            ///** 
+                //jq.getJSON('${ ui.actionLink("kenyaemrorderentry", "manifest/manifestForm", "requeueManifest") }',
+                    //{
+                        //manifestId : manifestId
+                    //})
+                    //.success(function (data) {
+                        //console.log('Success');
+                    //})
+                    //.error(function (xhr, status, err) {
+                        //console.log('AJAX error ' + JSON.stringify(xhr));
+                    //})
+                //}); 
+            //*/         
         });
     });
 

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
@@ -233,26 +233,10 @@ tr:nth-child(even) {background-color: #f2f2f2;}
         jq(document).on('click','.requeueButton',function(){
             // We requeue the manifest by changing its status to 'Submitted' and all order items to 'Sent'
             let manifestId = jq(this).val();
-            console.log('Manifest ID: ' + JSON.stringify(manifestId));
             ui.getFragmentActionAsJson('kenyaemrorderentry', 'manifest/manifestForm', 'requeueManifest', {manifestId : manifestId}, function (result) {
                 // Done Requeueing
-                console.log("Success: Manifest Number: " + manifestId + " requeued");
                 ui.reloadPage();
-                //ui.navigate('kenyaemrorderentry', 'orders/labOrdersSubmittedManifestHome', { manifestId: jq(this).val(),  returnUrl: location.href });
-            }); 
-            ///** 
-                //jq.getJSON('${ ui.actionLink("kenyaemrorderentry", "manifest/manifestForm", "requeueManifest") }',
-                    //{
-                        //manifestId : manifestId
-                    //})
-                    //.success(function (data) {
-                        //console.log('Success');
-                    //})
-                    //.error(function (xhr, status, err) {
-                        //console.log('AJAX error ' + JSON.stringify(xhr));
-                    //})
-                //}); 
-            //*/         
+            });        
         });
     });
 

--- a/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersCompleteWithErrorResultsManifestHome.gsp
@@ -3,17 +3,18 @@
     ui.includeJavascript("kenyaemrorderentry", "jquery.twbsPagination.min.js")
     ui.includeJavascript("kenyaemrorderentry", "ordersUtils.js")
 
+
     def menuItems = [
             [label: "Back to home", iconProvider: "kenyaui", icon: "buttons/back.png", label: "Back to home", href: ui.pageLink("kenyaemr", "userHome")]
     ]
 
     def manifestCategories = [
-            [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: "", id:"draftLink"],
+            [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
-            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
+            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ""],
             [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteResultManifestHome")],
     ]
 
@@ -97,11 +98,19 @@ tr:nth-child(even) {background-color: #f2f2f2;}
     background-color: cadetblue;
     color: white;
 }
+.requeueButton {
+    background-color: cadetblue;
+    color: white;
+}
 .viewButton:hover {
     background-color: steelblue;
     color: white;
 }
 .editButton:hover {
+    background-color: steelblue;
+    color: white;
+}
+.requeueButton:hover {
     background-color: steelblue;
     color: white;
 }
@@ -123,13 +132,9 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 <div class="ke-page-content">
     <div align="left">
 
-        <h2 style="color:steelblue">Manifest list [ Draft ]</h2>
+        <h2 style="color:steelblue">Manifest list [ Complete With Error Results ]</h2>
         <div>
-            <button type="button"
-                    onclick="ui.navigate('${ ui.pageLink("kenyaemrorderentry", "manifest/createManifest", [ returnUrl: ui.thisUrl() ])}')">
-                <img src="${ui.resourceLink("kenyaui", "images/glyphs/add.png")}"/>
-                Add new Manifest
-            </button>
+
         </div>
         <br/>
         <br/>
@@ -167,8 +172,8 @@ tr:nth-child(even) {background-color: #f2f2f2;}
     //On ready
     jq = jQuery;
     jq(function () {
-        showActivePageOnManifestNavigation('Draft');
-
+        // mark the activePage
+        showActivePageOnManifestNavigation('Complete With Error results');
         jq('#generateManifest').click(function () {
             jq.getJSON('${ ui.actionLink("kenyaemrorderentry", "patientdashboard/generalLabOrders", "generateViralLoadPayload") }')
                 .success(function (data) {
@@ -305,6 +310,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
             });
             actionTd.append(btnView);
             tr.append(actionTd);
+
             if (displayRecords[i].manifest.status == "Draft") {
                 var btnEdit = jq('<button/>', {
                     text: 'Edit',
@@ -314,6 +320,15 @@ tr:nth-child(even) {background-color: #f2f2f2;}
                 actionTd.append(btnEdit);
                 tr.append(actionTd);
             }
+
+            var btnRequeue = jq('<button/>', {
+                text: 'Re-queue',
+                class: 'requeueButton',
+                value: displayRecords[i].manifest.id
+            });
+            actionTd.append(btnRequeue);
+            tr.append(actionTd);
+
             jq('#manifest-list').append(tr);
         }
     }

--- a/omod/src/main/webapp/pages/orders/labOrdersIncompleteResultManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersIncompleteResultManifestHome.gsp
@@ -93,10 +93,14 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 .viewButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .editButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .viewButton:hover {
     background-color: steelblue;

--- a/omod/src/main/webapp/pages/orders/labOrdersIncompleteResultManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersIncompleteResultManifestHome.gsp
@@ -13,6 +13,7 @@
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ""],
+            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
             [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteResultManifestHome")],
     ]
 

--- a/omod/src/main/webapp/pages/orders/labOrdersManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersManifestHome.gsp
@@ -93,10 +93,14 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 .viewButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .editButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .viewButton:hover {
     background-color: steelblue;

--- a/omod/src/main/webapp/pages/orders/labOrdersManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersManifestHome.gsp
@@ -11,6 +11,7 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: "", id:"draftLink"],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],

--- a/omod/src/main/webapp/pages/orders/labOrdersOnHoldManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersOnHoldManifestHome.gsp
@@ -94,10 +94,14 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 .viewButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .editButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .viewButton:hover {
     background-color: steelblue;

--- a/omod/src/main/webapp/pages/orders/labOrdersOnHoldManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersOnHoldManifestHome.gsp
@@ -14,6 +14,7 @@
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ""],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
+            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
             [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ""],
     ]
 

--- a/omod/src/main/webapp/pages/orders/labOrdersOnHoldManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersOnHoldManifestHome.gsp
@@ -12,6 +12,7 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ""],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],

--- a/omod/src/main/webapp/pages/orders/labOrdersReadyToSendManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersReadyToSendManifestHome.gsp
@@ -94,10 +94,14 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 .viewButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .editButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .viewButton:hover {
     background-color: steelblue;

--- a/omod/src/main/webapp/pages/orders/labOrdersReadyToSendManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersReadyToSendManifestHome.gsp
@@ -14,6 +14,7 @@
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
+            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
             [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ""],
     ]
 

--- a/omod/src/main/webapp/pages/orders/labOrdersReadyToSendManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersReadyToSendManifestHome.gsp
@@ -12,6 +12,7 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ""],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],

--- a/omod/src/main/webapp/pages/orders/labOrdersSendingManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersSendingManifestHome.gsp
@@ -94,10 +94,14 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 .viewButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .editButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .viewButton:hover {
     background-color: steelblue;

--- a/omod/src/main/webapp/pages/orders/labOrdersSendingManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersSendingManifestHome.gsp
@@ -3,6 +3,7 @@
     ui.includeJavascript("kenyaemrorderentry", "jquery.twbsPagination.min.js")
     ui.includeJavascript("kenyaemrorderentry", "ordersUtils.js")
 
+
     def menuItems = [
             [label: "Back to home", iconProvider: "kenyaui", icon: "buttons/back.png", label: "Back to home", href: ui.pageLink("kenyaemr", "userHome")]
     ]
@@ -11,11 +12,11 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
-            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ""],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
-            [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ""],
+            [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
-            [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteResultManifestHome")],
+            [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ""],
     ]
 
     def actionRequired = [
@@ -124,7 +125,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 <div class="ke-page-content">
     <div align="left">
 
-        <h2 style="color:steelblue">Manifest list [ Incomplete results ]</h2>
+        <h2 style="color:steelblue">Manifest list [ Sending ]</h2>
         <div>
 
         </div>
@@ -164,9 +165,8 @@ tr:nth-child(even) {background-color: #f2f2f2;}
     //On ready
     jq = jQuery;
     jq(function () {
-// mark the activePage
-        showActivePageOnManifestNavigation('Incomplete results');
-
+        // mark the activePage
+        showActivePageOnManifestNavigation('Sending');
         jq('#generateManifest').click(function () {
             jq.getJSON('${ ui.actionLink("kenyaemrorderentry", "patientdashboard/generalLabOrders", "generateViralLoadPayload") }')
                 .success(function (data) {

--- a/omod/src/main/webapp/pages/orders/labOrdersSubmittedManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersSubmittedManifestHome.gsp
@@ -93,10 +93,14 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 .viewButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .editButton {
     background-color: cadetblue;
     color: white;
+    margin: 5px;
+    padding: 5px;
 }
 .viewButton:hover {
     background-color: steelblue;

--- a/omod/src/main/webapp/pages/orders/labOrdersSubmittedManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersSubmittedManifestHome.gsp
@@ -13,6 +13,7 @@
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
+            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
             [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteResultManifestHome")],
     ]
 

--- a/omod/src/main/webapp/pages/orders/labOrdersSubmittedManifestHome.gsp
+++ b/omod/src/main/webapp/pages/orders/labOrdersSubmittedManifestHome.gsp
@@ -11,6 +11,7 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],

--- a/omod/src/main/webapp/pages/orders/manifestOrdersCollectSampleHome.gsp
+++ b/omod/src/main/webapp/pages/orders/manifestOrdersCollectSampleHome.gsp
@@ -10,6 +10,7 @@
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
+            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
             [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteResultManifestHome")],
     ]
 

--- a/omod/src/main/webapp/pages/orders/manifestOrdersCollectSampleHome.gsp
+++ b/omod/src/main/webapp/pages/orders/manifestOrdersCollectSampleHome.gsp
@@ -8,6 +8,7 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],

--- a/omod/src/main/webapp/pages/orders/manifestOrdersMissingSamplesHome.gsp
+++ b/omod/src/main/webapp/pages/orders/manifestOrdersMissingSamplesHome.gsp
@@ -10,6 +10,7 @@
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
+            [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],
             [label: "Complete results", iconProvider: "kenyaui", icon: "", label: "Complete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteResultManifestHome")],
     ]
 

--- a/omod/src/main/webapp/pages/orders/manifestOrdersMissingSamplesHome.gsp
+++ b/omod/src/main/webapp/pages/orders/manifestOrdersMissingSamplesHome.gsp
@@ -8,6 +8,7 @@
             [label: "Draft", iconProvider: "kenyaui", icon: "", label: "Draft", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersManifestHome")],
             [label: "Ready to send", iconProvider: "kenyaui", icon: "", label: "Ready to send", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersReadyToSendManifestHome")],
             [label: "On hold", iconProvider: "kenyaui", icon: "", label: "On hold", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersOnHoldManifestHome")],
+            [label: "Sending", iconProvider: "kenyaui", icon: "", label: "Sending", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSendingManifestHome")],
             [label: "Submitted", iconProvider: "kenyaui", icon: "", label: "Submitted", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersSubmittedManifestHome")],
             [label: "Incomplete results", iconProvider: "kenyaui", icon: "", label: "Incomplete results", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersIncompleteResultManifestHome")],
             [label: "Complete With Errors", iconProvider: "kenyaui", icon: "", label: "Complete With Errors", href: ui.pageLink("kenyaemrorderentry", "orders/labOrdersCompleteWithErrorResultsManifestHome")],


### PR DESCRIPTION
KHP3-3443 lab manifest add new categories for manifests in error and in sending status

Screenshot 1 (sending):


![sending 2023-05-23 19-38-29](https://github.com/palladiumkenya/openmrs-module-kenyaemrorderentry/assets/97954453/9f8793d4-0be7-4a25-99b6-0a9a2c82377f)


Screenshot 2 (Reprocess):

![reprocess-1 2023-05-23 19-43-46](https://github.com/palladiumkenya/openmrs-module-kenyaemrorderentry/assets/97954453/340a7565-8b96-4670-94ba-6b46f7e54b7d)
![reprocess-2 2023-05-23 19-44-26](https://github.com/palladiumkenya/openmrs-module-kenyaemrorderentry/assets/97954453/c5cad69c-5f9d-4dfc-9692-0223d7b1812b)


![reprocess-3 2023-05-23 19-44-00](https://github.com/palladiumkenya/openmrs-module-kenyaemrorderentry/assets/97954453/41fe1889-2efe-47f3-84b6-211e0806fe2b)


