### PR TITLE
KHP3-5636 - Modified the justification codes displayed on the manifest order form

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/itext/ViralLoadLabManifestReport.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/itext/ViralLoadLabManifestReport.java
@@ -260,7 +260,7 @@ public class ViralLoadLabManifestReport {
             table.addCell(new Paragraph(uniqueNumber)).setFontSize(10);
         }
 
-        //Add Recency and Justification
+        // Add Recency
         String recencyIdentifier = "";
         PatientIdentifier recencyPatientIdentifier = null;
         PatientIdentifierType recencyIdentifierType = Utils.getRecencyIdentifierType();
@@ -271,6 +271,7 @@ public class ViralLoadLabManifestReport {
             }
         }
         table.addCell(new Paragraph(recencyIdentifier)).setFontSize(10);
+        // Add Justification
         table.addCell(new Paragraph(sample.getOrder().getOrderReason() != null ? LabOrderDataExchange.getOrderReasonCode(sample.getOrder().getOrderReason().getUuid()) : "")).setFontSize(10);
 
         table.addCell(new Paragraph(Utils.getSimpleDateFormat("dd/MM/yyyy").format(sample.getOrder().getPatient().getBirthdate()))).setFontSize(10);

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabOrderDataExchange.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabOrderDataExchange.java
@@ -164,7 +164,7 @@ public class LabOrderDataExchange {
     }
 
     /**
-     * Converter for concept to lab system code
+     * Converter for concept to lab system code (justification)
      * 1= Routine VL
      * 2=confirmation of
      * treatment failure (repeat VL)
@@ -190,16 +190,27 @@ public class LabOrderDataExchange {
         } else if (conceptUuid.equals("162080AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // baseline VL
             code = 5;
         } else if (conceptUuid.equals("1259AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // single drug substitution
-            code = 4;
+            code = 3;
         } else if (conceptUuid.equals("159882AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // breastfeeding
             code = 1;
-        } else if (conceptUuid.equals("163523AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // clinical failure
-            code = 3;
+        } else if (conceptUuid.equals("163718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // PMTCT NP
+            code = 8;
         } else if (conceptUuid.equals("161236AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // routine
             code = 1;
         } else if (conceptUuid.equals("160032AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // confirmation of persistent low viremia
             code = 6;
+        } else if (conceptUuid.equals("163523AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // Recency
+            code = 7;
+        } else if (conceptUuid.equals("f87f344a-62de-45ac-9cc0-b5bed81c289e")) { // PMTCT KP
+            code = 9;
+        } else if (conceptUuid.equals("bb9780b3-4f44-42fd-9e94-3958d36d106f")) { // 1ST VL
+            code = 10;
+        } else if (conceptUuid.equals("167391AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) { // Follow up
+            code = 11;
+        } else if (conceptUuid.equals("e299c5c6-5dc7-4977-9b9a-516252d4d582")) { //  Repeat VL after 3rd EAC
+            code = 12;
         }
+
         return code != null ? code.toString() : "";
     }
 


### PR DESCRIPTION
KHP3-5636 - Modified the justification codes displayed on the manifest order form

3= Single drug substitution -- done -- 1259AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA -- Answer on encounter form. Implies that a patient will receive a change in their current drug regimen.

7=Recency -- done -- 167389AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA -- Recency 

8= PMTCT NP -- done -- 163718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA -- PMTCT-NP

9=PMTCT KP -- done -- 2001237 -- f87f344a-62de-45ac-9cc0-b5bed81c289e -- PMTCT-KP

10= 1ST VL -- done -- 2001236 -- bb9780b3-4f44-42fd-9e94-3958d36d106f -- 1st VL

11=Follow up -- done -- 167391AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA -- Follow Up

12= Repeat VL after 3rd EAC -- done -- 2031219 -- e299c5c6-5dc7-4977-9b9a-516252d4d582 -- Repeat VL after 3rd EAC