### PR TITLE
Differentiate eid fl uand vl manifest system

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>kenyaemrorderentry</artifactId>
-		<version>1.6.6</version>
+		<version>1.6.7</version>
 	</parent>
 
 	<artifactId>kenyaemrorderentry-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/ModuleConstants.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/ModuleConstants.java
@@ -45,6 +45,11 @@ public class ModuleConstants {
     public static final String LAB_SYSTEM_DATE_PATTERN = "yyyy-MM-dd";
     public static final String GP_LAB_SYSTEM_IN_USE = "kemrorder.labsystem_identifier";
 
+    // LAB SYSTEM (Different for VL, EID, FLU)
+    public static final String GP_VL_LAB_SYSTEM_IN_USE = "kemrorder.vl.labsystem_identifier";
+    public static final String GP_EID_LAB_SYSTEM_IN_USE = "kemrorder.eid.labsystem_identifier";
+    public static final String GP_FLU_LAB_SYSTEM_IN_USE = "kemrorder.flu.labsystem_identifier";
+
     //EID
     public static final String ENABLE_EID_FUNCTION = "enable_orderentry_manifest_eid_function";
 
@@ -75,6 +80,9 @@ public class ModuleConstants {
     public static final String GP_EXPRESS_PAYMENT_METHODS = "kenyaemrorderentry.facilitywidelims.expressPaymentMethods";
     public static final String VISIT_ATTRIBUTE_PAYMENT_METHOD_UUID = "e6cb0c3b-04b0-4117-9bc6-ce24adbda802";
 
-
-
+    // Manifest Types e.g VL, EID, FLU etc
+    // public static final int NO_MANIFEST_TYPE_CONFIGURED = 0;
+    // public static final int MANIFEST_TYPE_EID = 1;
+    // public static final int MANIFEST_TYPE_VL = 2;
+    // public static final int MANIFEST_TYPE_FLU = 3;
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/impl/KenyaemrOrdersServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/api/service/impl/KenyaemrOrdersServiceImpl.java
@@ -94,9 +94,10 @@ public class KenyaemrOrdersServiceImpl extends BaseOpenmrsService implements Ken
             if(manifestId == null) {
                 System.out.println("Manifest ID fix: Saving a new manifest");
                 LabOrderDataExchange labOrderDataExchange = new LabOrderDataExchange();
-                if(LabOrderDataExchange.getSystemType() == ModuleConstants.LABWARE_SYSTEM) {
+                Integer manifestType = labManifest.getManifestType();
+                if(LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.LABWARE_SYSTEM) {
                     String mType = "E";
-                    Integer manifestType = labManifest.getManifestType();
+                    
                     if(manifestType == LabManifest.EID_TYPE) {
                         mType = "E";
                     } else if(manifestType == LabManifest.VL_TYPE) {

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/ChaiSystemWebRequest.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/ChaiSystemWebRequest.java
@@ -76,10 +76,12 @@ public class ChaiSystemWebRequest extends LabWebRequest {
         String FLUServerPullUrl = gpFLUServerPullUrl.getPropertyValue();
         String FLUApiToken = gpFLUApiToken.getPropertyValue();
 
-        if ((toProcess.getManifestType() == LabManifest.VL_TYPE && (StringUtils.isBlank(VLServerPushUrl) || StringUtils.isBlank(VLServerPullUrl) || StringUtils.isBlank(VLApiToken)))
-                || (toProcess.getManifestType() == LabManifest.EID_TYPE && (StringUtils.isBlank(EIDServerPushUrl) || StringUtils.isBlank(EIDServerPullUrl) || StringUtils.isBlank(EIDApiToken)))
-                || (toProcess.getManifestType() == LabManifest.FLU_TYPE && (StringUtils.isBlank(FLUServerPushUrl) || StringUtils.isBlank(FLUServerPullUrl) || StringUtils.isBlank(FLUApiToken)))
-                || LabOrderDataExchange.getSystemType() == ModuleConstants.NO_SYSTEM_CONFIGURED
+        Integer manifestType = toProcess.getManifestType();
+
+        if ((manifestType == LabManifest.VL_TYPE && (StringUtils.isBlank(VLServerPushUrl) || StringUtils.isBlank(VLServerPullUrl) || StringUtils.isBlank(VLApiToken)))
+                || (manifestType == LabManifest.EID_TYPE && (StringUtils.isBlank(EIDServerPushUrl) || StringUtils.isBlank(EIDServerPullUrl) || StringUtils.isBlank(EIDApiToken)))
+                || (manifestType == LabManifest.FLU_TYPE && (StringUtils.isBlank(FLUServerPushUrl) || StringUtils.isBlank(FLUServerPullUrl) || StringUtils.isBlank(FLUApiToken)))
+                || LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.NO_SYSTEM_CONFIGURED
         ) {
             System.err.println("CHAI Lab Results: Please set credentials for posting lab requests to the CHAI system");
             return false;

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/EdarpSystemWebRequest.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/EdarpSystemWebRequest.java
@@ -79,10 +79,12 @@ public class EdarpSystemWebRequest extends LabWebRequest {
         String FLUServerPullUrl = gpFLUServerPullUrl.getPropertyValue();
         String FLUApiToken = gpFLUApiToken.getPropertyValue();
 
-        if ((toProcess.getManifestType() == LabManifest.VL_TYPE && (StringUtils.isBlank(VLServerPushUrl) || StringUtils.isBlank(VLServerPullUrl) || StringUtils.isBlank(VLApiToken)))
-                || (toProcess.getManifestType() == LabManifest.EID_TYPE && (StringUtils.isBlank(EIDServerPushUrl) || StringUtils.isBlank(EIDServerPullUrl) || StringUtils.isBlank(EIDApiToken)))
-                || (toProcess.getManifestType() == LabManifest.FLU_TYPE && (StringUtils.isBlank(FLUServerPushUrl) || StringUtils.isBlank(FLUServerPullUrl) || StringUtils.isBlank(FLUApiToken)))
-                || LabOrderDataExchange.getSystemType() == ModuleConstants.NO_SYSTEM_CONFIGURED
+        Integer manifestType = toProcess.getManifestType();
+
+        if ((manifestType == LabManifest.VL_TYPE && (StringUtils.isBlank(VLServerPushUrl) || StringUtils.isBlank(VLServerPullUrl) || StringUtils.isBlank(VLApiToken)))
+                || (manifestType == LabManifest.EID_TYPE && (StringUtils.isBlank(EIDServerPushUrl) || StringUtils.isBlank(EIDServerPullUrl) || StringUtils.isBlank(EIDApiToken)))
+                || (manifestType == LabManifest.FLU_TYPE && (StringUtils.isBlank(FLUServerPushUrl) || StringUtils.isBlank(FLUServerPullUrl) || StringUtils.isBlank(FLUApiToken)))
+                || LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.NO_SYSTEM_CONFIGURED
         ) {
             System.err.println("EDARP Lab Results: Please set credentials for posting lab requests to the EDARP system");
             return false;

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabWebRequest.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabWebRequest.java
@@ -148,7 +148,7 @@ public abstract class LabWebRequest {
                 return test;
             }
 
-            if (LabOrderDataExchange.getSystemType() == ModuleConstants.CHAI_SYSTEM || LabOrderDataExchange.getSystemType() == ModuleConstants.EDARP_SYSTEM) {
+            if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.CHAI_SYSTEM || LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.EDARP_SYSTEM) {
                 System.out.println("Creating payload for CHAI or EDARP EID");
                 test.put("dob", dob);
                 test.put("sex", patient.getGender().equals("M") ? "1" : patient.getGender().equals("F") ? "2" : "3");
@@ -171,7 +171,7 @@ public abstract class LabWebRequest {
                 test.put("mother_age", (heiMothersAgeObject != null && heiMothersAgeObject.get("mothersAge") != null) ? heiMothersAgeObject.get("mothersAge").toString() : "" );
                 test.put("ccc_no", Utils.getMothersUniquePatientNumber(patient) !=null ? Utils.getMothersUniquePatientNumber(patient) : "");
 
-            } else if (LabOrderDataExchange.getSystemType() == ModuleConstants.LABWARE_SYSTEM) {
+            } else if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.LABWARE_SYSTEM) {
                 System.out.println("Creating payload for labware EID");
                 test.put("sample_type", sampleType);
                 test.put("pat_name", fullName);

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabwareSystemWebRequest.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabwareSystemWebRequest.java
@@ -80,10 +80,12 @@ public class LabwareSystemWebRequest extends LabWebRequest {
         String FLUServerPullUrl = gpFLUServerPullUrl.getPropertyValue();
         String FLUApiToken = gpFLUApiToken.getPropertyValue();
 
-        if ((toProcess.getManifestType() == LabManifest.VL_TYPE && (StringUtils.isBlank(VLServerPushUrl) || StringUtils.isBlank(VLServerPullUrl) || StringUtils.isBlank(VLApiToken)))
-                || (toProcess.getManifestType() == LabManifest.EID_TYPE && (StringUtils.isBlank(EIDServerPushUrl) || StringUtils.isBlank(EIDServerPullUrl) || StringUtils.isBlank(EIDApiToken)))
-                || (toProcess.getManifestType() == LabManifest.FLU_TYPE && (StringUtils.isBlank(FLUServerPushUrl) || StringUtils.isBlank(FLUServerPullUrl) || StringUtils.isBlank(FLUApiToken)))
-                || LabOrderDataExchange.getSystemType() == ModuleConstants.NO_SYSTEM_CONFIGURED
+        Integer manifestType = toProcess.getManifestType();
+
+        if ((manifestType == LabManifest.VL_TYPE && (StringUtils.isBlank(VLServerPushUrl) || StringUtils.isBlank(VLServerPullUrl) || StringUtils.isBlank(VLApiToken)))
+                || (manifestType == LabManifest.EID_TYPE && (StringUtils.isBlank(EIDServerPushUrl) || StringUtils.isBlank(EIDServerPullUrl) || StringUtils.isBlank(EIDApiToken)))
+                || (manifestType == LabManifest.FLU_TYPE && (StringUtils.isBlank(FLUServerPushUrl) || StringUtils.isBlank(FLUServerPullUrl) || StringUtils.isBlank(FLUApiToken)))
+                || LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.NO_SYSTEM_CONFIGURED
         ) {
             System.err.println("Labware Lab Results: Please set credentials for posting lab requests to the labware system");
             return false;

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabwareSystemWebRequest.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/labDataExchange/LabwareSystemWebRequest.java
@@ -545,7 +545,6 @@ public class LabwareSystemWebRequest extends LabWebRequest {
         ObjectNode node = baselinePostRequestPayload(order, dateSampleCollected, dateSampleSeparated, sampleType, manifestID);
 
         if (!node.isEmpty()) {
-
             if (getManifestType() == LabManifest.FLU_TYPE) {
                 // Any custom payload for LABWARE FLU
             } else {
@@ -558,15 +557,7 @@ public class LabwareSystemWebRequest extends LabWebRequest {
                 node.put("recency_id", "");
                 node.put("emr_shipment", StringUtils.isNotBlank(manifestID) ? manifestID : "");
                 node.put("date_separated", Utils.getSimpleDateFormat("yyyy-MM-dd").format(dateSampleSeparated));
-
-
-                // node.put("mfl_code", Utils.getDefaultLocationMflCode(Utils.getDefaultLocation()));
-                if (order.getPatient().getGender().equals("F")) {
-                    node.put("female_status", "none");
-                }
             }
-
-            // System.out.println("Order Entry: Using LABWARE System payload: " + node.toPrettyString());
         }
 
         return node;

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/task/PullViralLoadLabResultsTask.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/task/PullViralLoadLabResultsTask.java
@@ -48,25 +48,6 @@ public class PullViralLoadLabResultsTask extends AbstractTask {
 
                 LabWebRequest labSystemConnectionRequest;
 
-                if (LabOrderDataExchange.getSystemType() == ModuleConstants.CHAI_SYSTEM) {
-                    // System.out.println("Order Entry: Using CHAI System");
-                    labSystemConnectionRequest = new ChaiSystemWebRequest();
-                } else if (LabOrderDataExchange.getSystemType() == ModuleConstants.LABWARE_SYSTEM){
-                    // System.out.println("Order Entry: Using LABWARE System");
-                    labSystemConnectionRequest = new LabwareSystemWebRequest();
-                } else if (LabOrderDataExchange.getSystemType() == ModuleConstants.EDARP_SYSTEM){
-                    // System.out.println("Order Entry: Using EDARP System");
-                    labSystemConnectionRequest = new EdarpSystemWebRequest();
-                } else {
-                    System.out.println("LAB GET: No lab system has been configured. Please configure the global properties");
-                    return;
-                }
-
-//                if (!labSystemConnectionRequest.checkRequirements()) {
-//                    System.out.println("LAB GET: Failed to satisfy requirements for pulling samples. Please configure appropriate global properties for your facility");
-//                    return;
-//                }
-
                 GlobalProperty gpLastProcessedManifest = Context.getAdministrationService().getGlobalPropertyObject(ModuleConstants.GP_MANIFEST_LAST_PROCESSED);
                 GlobalProperty gpRetryPeriodForIncompleteResults = Context.getAdministrationService().getGlobalPropertyObject(ModuleConstants.GP_RETRY_PERIOD_FOR_ORDERS_WITH_INCOMPLETE_RESULTS);
                 GlobalProperty gpLabTatForVlResults = Context.getAdministrationService().getGlobalPropertyObject(ModuleConstants.GP_LAB_TAT_FOR_VL_RESULTS);
@@ -203,6 +184,22 @@ public class PullViralLoadLabResultsTask extends AbstractTask {
                 for (LabManifestOrder manifestOrder : ordersWithPendingResults) {
                     orderIds.add(manifestOrder.getOrder().getOrderId());
                     manifestOrderIds.add(manifestOrder.getId());
+                }
+
+                int manifestType = manifestToUpdateResults.getManifestType();
+
+                if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.CHAI_SYSTEM) {
+                    // System.out.println("Order Entry: Using CHAI System");
+                    labSystemConnectionRequest = new ChaiSystemWebRequest();
+                } else if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.LABWARE_SYSTEM){
+                    // System.out.println("Order Entry: Using LABWARE System");
+                    labSystemConnectionRequest = new LabwareSystemWebRequest();
+                } else if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.EDARP_SYSTEM){
+                    // System.out.println("Order Entry: Using EDARP System");
+                    labSystemConnectionRequest = new EdarpSystemWebRequest();
+                } else {
+                    System.out.println("LAB GET: No lab system has been configured. Please configure the global properties");
+                    return;
                 }
 
                 // Pull Lab Results

--- a/api/src/main/java/org/openmrs/module/kenyaemrorderentry/task/PushLabRequestsTask.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrorderentry/task/PushLabRequestsTask.java
@@ -47,25 +47,6 @@ public class PushLabRequestsTask extends AbstractTask {
 
                 LabWebRequest labSystemConnectionRequest;
 
-                if (LabOrderDataExchange.getSystemType() == ModuleConstants.CHAI_SYSTEM) {
-                    // System.out.println("Order Entry: Using CHAI System");
-                    labSystemConnectionRequest = new ChaiSystemWebRequest();
-                } else if (LabOrderDataExchange.getSystemType() == ModuleConstants.LABWARE_SYSTEM){
-                    // System.out.println("Order Entry: Using LABWARE System");
-                    labSystemConnectionRequest = new LabwareSystemWebRequest();
-                } else if (LabOrderDataExchange.getSystemType() == ModuleConstants.EDARP_SYSTEM){
-                    // System.out.println("Order Entry: Using EDARP System");
-                    labSystemConnectionRequest = new EdarpSystemWebRequest();
-                } else {
-                    System.out.println("LAB POST: No lab system has been configured. Please configure the global properties");
-                    return;
-                }
-
-//                if (!labSystemConnectionRequest.checkRequirements()) {
-//                    System.out.println("LAB POST: Failed to satisfy requirements for pushing samples. Please configure appropriate global properties for your facility");
-//                    return;
-//                }
-
                 // Get a manifest ready to be sent
                 LabManifest toProcess = null;
                 String manifestStatus = "";
@@ -103,6 +84,22 @@ public class PushLabRequestsTask extends AbstractTask {
                         toProcess.setStatus("Sending");
                         kenyaemrOrdersService.saveLabOrderManifest(toProcess);
                     }
+                }
+
+                int manifestType = toProcess.getManifestType();
+
+                if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.CHAI_SYSTEM) {
+                    // System.out.println("Order Entry: Using CHAI System");
+                    labSystemConnectionRequest = new ChaiSystemWebRequest();
+                } else if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.LABWARE_SYSTEM){
+                    // System.out.println("Order Entry: Using LABWARE System");
+                    labSystemConnectionRequest = new LabwareSystemWebRequest();
+                } else if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.EDARP_SYSTEM){
+                    // System.out.println("Order Entry: Using EDARP System");
+                    labSystemConnectionRequest = new EdarpSystemWebRequest();
+                } else {
+                    System.out.println("LAB POST: No lab system has been configured. Please configure the global properties");
+                    return;
                 }
 
                 boolean checkIfSent = true;

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>kenyaemrorderentry</artifactId>
-		<version>1.6.6</version>
+		<version>1.6.7</version>
 	</parent>
 
 	<artifactId>kenyaemrorderentry-omod</artifactId>

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/web/controller/KenyaemrOrderRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/web/controller/KenyaemrOrderRestController.java
@@ -165,11 +165,11 @@ public class KenyaemrOrderRestController extends BaseRestController {
         Integer manifestTypeCode = labManifest.getManifestType();
         
         if (manifestTypeCode == LabManifest.EID_TYPE) {
-            activeOrdersNotInManifest = labOrderDataExchange.getActiveEidOrdersNotInManifest(null, labManifest.getStartDate(), labManifest.getEndDate());
+            activeOrdersNotInManifest = labOrderDataExchange.getActiveEidOrdersNotInManifest(manifestTypeCode, labManifest.getStartDate(), labManifest.getEndDate());
         } else if (manifestTypeCode == LabManifest.VL_TYPE) {
-            activeOrdersNotInManifest = labOrderDataExchange.getActiveViralLoadOrdersNotInManifest(null, labManifest.getStartDate(), labManifest.getEndDate());
+            activeOrdersNotInManifest = labOrderDataExchange.getActiveViralLoadOrdersNotInManifest(manifestTypeCode, labManifest.getStartDate(), labManifest.getEndDate());
         } else if (manifestTypeCode == LabManifest.FLU_TYPE) {
-            activeOrdersNotInManifest = labOrderDataExchange.getActiveFluOrdersNotInManifest(null, labManifest.getStartDate(), labManifest.getEndDate());
+            activeOrdersNotInManifest = labOrderDataExchange.getActiveFluOrdersNotInManifest(manifestTypeCode, labManifest.getStartDate(), labManifest.getEndDate());
         }
 
         // orders

--- a/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/web/resource/LabManifestOrderResource.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrorderentry/web/resource/LabManifestOrderResource.java
@@ -66,11 +66,13 @@ public class LabManifestOrderResource extends DataDelegatingCrudResource<LabMani
         String sampleType = labManifestOrder.getSampleType();
         LabWebRequest payloadGenerator = null;
 
-        if (LabOrderDataExchange.getSystemType() == ModuleConstants.CHAI_SYSTEM) {
+        Integer manifestType = manifest.getManifestType();
+
+        if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.CHAI_SYSTEM) {
             payloadGenerator = new ChaiSystemWebRequest();
-        } else if (LabOrderDataExchange.getSystemType() == ModuleConstants.LABWARE_SYSTEM) {
+        } else if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.LABWARE_SYSTEM) {
             payloadGenerator = new LabwareSystemWebRequest();
-        } else if (LabOrderDataExchange.getSystemType() == ModuleConstants.EDARP_SYSTEM) {
+        } else if (LabOrderDataExchange.getSystemType(manifestType) == ModuleConstants.EDARP_SYSTEM) {
             payloadGenerator = new EdarpSystemWebRequest();
         }
         

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -341,9 +341,33 @@
 
 	<globalProperty>
 		<property>kemrorder.labsystem_identifier</property>
-		<defaultValue></defaultValue>
+		<defaultValue>LABWARE</defaultValue>
 		<description>
 			The name of the lab system in use. Accepted options are CHAI,LABWARE,EDARP. Please note these are case sensitive
+		</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>kemrorder.vl.labsystem_identifier</property>
+		<defaultValue>LABWARE</defaultValue>
+		<description>
+			The name of the VL lab system in use. Accepted options are CHAI,LABWARE,EDARP. Please note these are case sensitive
+		</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>kemrorder.eid.labsystem_identifier</property>
+		<defaultValue>LABWARE</defaultValue>
+		<description>
+			The name of the EID lab system in use. Accepted options are CHAI,LABWARE,EDARP. Please note these are case sensitive
+		</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>kemrorder.flu.labsystem_identifier</property>
+		<defaultValue>LABWARE</defaultValue>
+		<description>
+			The name of the FLU lab system in use. Accepted options are CHAI,LABWARE,EDARP. Please note these are case sensitive
 		</description>
 	</globalProperty>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openmrs.module</groupId>
     <artifactId>kenyaemrorderentry</artifactId>
-    <version>1.6.6</version>
+    <version>1.6.7</version>
     <packaging>pom</packaging>
     <name>KenyaEMR Order Entry Module</name>
     <description>Drug Order Entry for OpenMRS 2.x</description>


### PR DESCRIPTION
Differentiate eid fl uand vl manifest system i.e
Now the systems can be set to be different for each of the manifest types e.g
VL  -- Labware
EID -- EDARP
FLU -- CHAI

The significant global parameters are:

kemrorder.vl.labsystem_identifier,
kemrorder.eid.labsystem_identifier,
kemrorder.flu.labsystem_identifier

If the respective variable is not set for a particular manifest type, the default fallback is:

kemrorder.labsystem_identifier